### PR TITLE
Fix measure for Range

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,7 @@ impl<T: Abomonation> Abomonation for std::ops::Range<T> {
         Some(bytes)
     }
     #[inline] fn extent(&self) -> usize {
-        self.start.extent() << 1
+        self.start.extent() + self.end.extent()
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -32,6 +32,16 @@ use abomonation::*;
 #[test] fn test_vec_u_s_size() { _test_size(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 
 #[test]
+fn test_range_string_pass() {
+    _test_pass(String::from("a")..String::from("abc"));
+}
+
+#[test]
+fn test_range_string_size() {
+    _test_size(String::from("a")..String::from("abc"));
+}
+
+#[test]
 fn test_phantom_data_for_non_abomonatable_type() {
     use std::marker::PhantomData;
     struct NotAbomonatable;


### PR DESCRIPTION
## Summary
- fix `Abomonation` extent calculation for `Range<T>`
- test encoding/size for `Range<String>`

## Testing
- `cargo test` *(fails: unsafe precondition(s) violated in test_alignment)*

------
https://chatgpt.com/codex/tasks/task_e_6867c7d861e88325a38ccdc4bd0afd5b